### PR TITLE
Apply "Commercial Rounding" to treat positive and negative values symmetrically

### DIFF
--- a/addon/format-number.js
+++ b/addon/format-number.js
@@ -50,8 +50,9 @@ function formatNumber(number, precision, thousand, decimal) {
   const usePrecision = checkPrecision(opts.precision);
 
   // Do some calc:
-  const fixedNumber = toFixed(number || 0, usePrecision);
-  const negative = fixedNumber < 0 ? "-" : "";
+  const initiallyNegative = `${number}`.indexOf("-") === 0;
+  const fixedNumber = toFixed(Math.abs(number) || 0, usePrecision);
+  const negative = initiallyNegative && fixedNumber > 0 ? "-" : "";
   const base = String(parseInt(Math.abs(fixedNumber), 10));
   const mod = base.length > 3 ? base.length % 3 : 0;
 

--- a/tests/unit/format-number-test.js
+++ b/tests/unit/format-number-test.js
@@ -28,3 +28,19 @@ test("formatNumber()", function(assert) {
 test("handles -0.00 stripping -", function(assert) {
   assert.equal(formatNumber(-0.0000000567, 2), "0.00", 'Removes - from -0.00');
 });
+
+test("Use 'Commercial Rounding' rule to treat positive and negative values symmetrically", function(assert) {
+  assert.equal(formatNumber(-0.95, 1), "-1.0", 'Rounds -0.95 to -1.0');
+  assert.equal(formatNumber(-0.96, 1), "-1.0", 'Rounds -0.96 to -1.0');
+  assert.equal(formatNumber(-0.94, 1), "-0.9", 'Rounds -0.94 to -0.9');
+  assert.equal(formatNumber(-0.85, 1), "-0.9", 'Rounds -0.85 to -0.9');
+  assert.equal(formatNumber(-0.86, 1), "-0.9", 'Rounds -0.86 to -0.9');
+  assert.equal(formatNumber(-0.84, 1), "-0.8", 'Rounds -0.84 to -0.8');
+
+  assert.equal(formatNumber(0.95, 1), "1.0", 'Rounds 0.95 to 1.0');
+  assert.equal(formatNumber(0.96, 1), "1.0", 'Rounds 0.96 to 1.0');
+  assert.equal(formatNumber(0.94, 1), "0.9", 'Rounds 0.94 to 0.9');
+  assert.equal(formatNumber(0.85, 1), "0.9", 'Rounds 0.85 to 0.9');
+  assert.equal(formatNumber(0.86, 1), "0.9", 'Rounds 0.86 to 0.9');
+  assert.equal(formatNumber(0.84, 1), "0.8", 'Rounds 0.84 to 0.8');
+});


### PR DESCRIPTION
Found that rounding was not working as expected.  -0.95 was rounding to 0 when I used 1 significant digit, when I was expecting -1.0.  Updated to treat +/- numbers symmetrically