### PR TITLE
Fix mistake in documentation for unformat

### DIFF
--- a/addon/unformat.js
+++ b/addon/unformat.js
@@ -19,7 +19,7 @@ import { number } from "./settings";
  * @method unformat
  * @for accounting
  * @param {String|Array<String>} value The string or array of strings containing the number/s to parse.
- * @param {Number}               decimal Number of decimal digits of the resultant number
+ * @param {String}               (optional) the value of the decimal separator, e.g. "." in USD or "," in EUR
  * @return {Float} The parsed number
  */
 function unformat(value, decimal) {


### PR DESCRIPTION
We can see that the updated documentation is correct by examining lines 41/42

```
// Default decimal point comes from settings, but could be set to eg. "," in opts:
  decimal = decimal || number.decimal;
```